### PR TITLE
Improved default guess for namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje-readme "1.0.3"
+(defproject midje-readme "1.0.4-SNAPSHOT"
   :description "A Leiningen plugin to pull tests from your README.md into midje."
   :url "https://github.com/boxed/midje-readme"
   :license {:name "Eclipse Public License"
@@ -8,4 +8,5 @@
   :scm {:name "git"
         :url "https://github.com/boxed/midje-readme"}
   :jar-exclusions [#"\.cljx|\.swp|\.swo|\.DS_Store"]
-  :eval-in-leiningen true)
+  :eval-in-leiningen true
+  :profiles {:dev {:dependencies [[midje "1.6.3"]]}})

--- a/test/midje_readme/plugin_test.clj
+++ b/test/midje_readme/plugin_test.clj
@@ -1,0 +1,22 @@
+(ns midje-readme.plugin-test
+  (:require [midje-readme.plugin :ref :all]
+            [midje.sweet :refer :all]
+            [midje.util :refer [testable-privates]]))
+
+(testable-privates midje-readme.plugin
+                   guess-namespace-to-use-for-require)
+
+(facts "guess-namespace-to-use-for-require (using Leiningen default)"
+  (fact "\"no\" group, simple name (lein new abc)"
+    (guess-namespace-to-use-for-require {:group "abc" :name "abc"})
+    => "abc.core")
+  (fact "\"no\" group, complex name (lein new def.ghi)"
+    (guess-namespace-to-use-for-require {:group "def.ghi" :name "def.ghi"})
+    => "def.ghi")
+  (fact "group, simple name (lein new jkl.mno/pqr)"
+    (guess-namespace-to-use-for-require {:group "jkl.mno" :name "pqr"})
+    => "jkl.mno.pqr")
+  (fact "group, complex name (lein new sru.wxy/zab.cde)"
+    (guess-namespace-to-use-for-require {:group "sru.wxy" :name "zab.cde"})
+    => "sru.wxy.zab.cde"))
+


### PR DESCRIPTION
Trying to pick a namespace for readme.clj according to the defaults used
by "lein new" - the current version does not work well for projects with groups.
