### PR TITLE
Recompile test namespace on readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,3 @@ You might want to add test/readme.clj to your .gitignore too.
 You can show that your README is tested with this badge: [![Examples tested with midje-readme](http://img.shields.io/badge/readme-tested-brightgreen.svg)](https://github.com/boxed/midje-readme) Copy paste the markdown syntax below:
 
     [![Examples tested with midje-readme](http://img.shields.io/badge/readme-tested-brightgreen.svg)](https://github.com/boxed/midje-readme)
-
-
-
-## Restrictions
-
-Changes in README.md will not be picked up by "lein midje :autotest"

--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
         :url "https://github.com/boxed/midje-readme"}
   :jar-exclusions [#"\.cljx|\.swp|\.swo|\.DS_Store"]
   :eval-in-leiningen true
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]}})
+  :profiles {:dev {:dependencies [[midje "1.6.3"]
+                                  [watchtower "0.1.1"]]}})

--- a/src/midje_readme/plugin.clj
+++ b/src/midje_readme/plugin.clj
@@ -1,6 +1,15 @@
 (ns midje-readme.plugin
   (:require [leiningen.core.eval :refer :all]
-            [leiningen.new.templates :as templates]))
+            [leiningen.new.templates :as templates]
+            [watchtower.core :as wt]))
+
+(def README_FILENAME "README.md")
+
+(def OUTPUT_FILENAME "test/readme.clj")
+
+(defn- readme? [file]
+  (and (= "." (.getParent file))
+       (= README_FILENAME (.getName file))))
 
 (defn readme-to-midje-test [readme require-str]
   (let [keep-line (atom false)
@@ -26,15 +35,21 @@
      group
      (format "%s.%s" group name))))
 
+(defn write-readme-tests! [project]
+  (spit OUTPUT_FILENAME
+        (readme-to-midje-test (slurp README_FILENAME)
+                              (or (get-in project [:midje-readme :require])
+                                  (format "[%s :refer :all]"
+                                          (guess-namespace-to-use-for-require project))))))
+
 (defn middleware [project]
   (let [used-clojure-version (read-string (with-out-str (eval-in project '(prn *clojure-version*))))]
     (if (or (> (:major used-clojure-version) 1)
             (> (:minor used-clojure-version) 3))
-      (spit "test/readme.clj"
-            (readme-to-midje-test (slurp "README.md")
-                                  (or (get-in project [:midje-readme :require])
-                                      (format "[%s :refer :all]"
-                                              (guess-namespace-to-use-for-require project)))))
+      (wt/watcher ["."]
+        (wt/rate 100)
+        (wt/file-filter readme?)
+        (wt/on-change (fn [_] (write-readme-tests! project))))
       (do
         (clojure.java.io/delete-file "test/readme.clj" true)
         (println "Warning: midje-readme doesn't support clojure < 1.4. The readme will not be tested"))))

--- a/src/midje_readme/plugin.clj
+++ b/src/midje_readme/plugin.clj
@@ -1,5 +1,8 @@
 (ns midje-readme.plugin
-  (:require [leiningen.core.eval :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io]
+            [leiningen.core.main :refer [warn]]
+            [leiningen.core.eval :refer :all]
             [leiningen.new.templates :as templates]
             [watchtower.core :as wt]))
 
@@ -7,27 +10,31 @@
 
 (def OUTPUT_FILENAME "test/readme.clj")
 
+(def ^:private is-code-start? (comp #{"```clojure"} str/trim))
+
+(def ^:private is-code-stop?  (comp #{"```"} str/trim))
+
 (defn- readme? [file]
   (and (= "." (.getParent file))
        (= README_FILENAME (.getName file))))
 
+(defn- process-readme-line [keep-line line]
+  (cond
+   (and (is-code-start? line) (not keep-line))
+     [true "(use 'midje.sweet) (ns readme) (fact"]
+   (and (is-code-stop? line) keep-line)
+     [false ")"]
+   :else
+     [keep-line (if keep-line line "")]))
+
 (defn readme-to-midje-test [readme require-str]
-  (let [keep-line (atom false)
-        is-code-start #(= (clojure.string/trim %1) "```clojure")
-        is-code-stop #(= (clojure.string/trim %1) "```")]
-    (clojure.string/join "\n" (assoc
-                                (into []
-                                      (for [line (clojure.string/split-lines readme)]
-                                         (cond
-                                          (and (is-code-start line) (not @keep-line))
-                                            (do (swap! keep-line not) "(use 'midje.sweet) (ns readme) (fact")
-                                          (and (is-code-stop line) @keep-line)
-                                            (do (swap! keep-line not) ")")
-                                          :else
-                                             (if @keep-line
-                                               line
-                                                ""))))
-                                0 (format "(ns readme (:use midje.sweet) (:require %s)) (def ... :...)" require-str)))))
+  (let [acc   [(format "(ns readme (:use midje.sweet) (:require %s)) (def ... :...)" require-str)]
+        lines (rest (str/split-lines readme))]
+    (str/join "\n" (loop [acc acc, keep-line false, [line & rest] lines]
+                     (if-not line
+                       acc
+                       (let [[keep-line output] (process-readme-line keep-line line)]
+                         (recur (conj acc output) keep-line rest)))))))
 
 (defn- guess-namespace-to-use-for-require [{:keys [group name]}]
   (templates/multi-segment

--- a/src/midje_readme/plugin.clj
+++ b/src/midje_readme/plugin.clj
@@ -51,7 +51,7 @@
         (wt/file-filter readme?)
         (wt/on-change (fn [_] (write-readme-tests! project))))
       (do
-        (clojure.java.io/delete-file "test/readme.clj" true)
-        (println "Warning: midje-readme doesn't support clojure < 1.4. The readme will not be tested"))))
+        (io/delete-file OUTPUT_FILENAME true)
+        (warn "Warning: midje-readme doesn't support clojure < 1.4. The readme will not be tested"))))
 
   project)


### PR DESCRIPTION
Closes #5 

Brought in watchtower library, but it's pretty small (and used by CLJX so in many projects) - mechanism is just complicated enough to discourage rolling our own.

Also this includes some creep using leiningen's warning mechanism and skipping the atom, but happy to back those out if out of scope.

