### PR TITLE
Watchtower dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,6 @@
         :url "https://github.com/boxed/midje-readme"}
   :deploy-repositories [["releases" :clojars]]
   :jar-exclusions [#"\.cljx|\.swp|\.swo|\.DS_Store"]
+  :dependencies [[watchtower "0.1.1"]]
   :eval-in-leiningen true
-  :profiles {:dev {:dependencies [[midje "1.6.3"]
-                                  [watchtower "0.1.1"]]}})
+  :profiles {:dev {:dependencies [[midje "1.6.3"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje-readme "1.0.7-SNAPSHOT"
+(defproject midje-readme "1.0.7"
   :description "A Leiningen plugin to pull tests from your README.md into midje."
   :url "https://github.com/boxed/midje-readme"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject midje-readme "1.0.7"
+(defproject midje-readme "1.0.8-SNAPSHOT"
   :description "A Leiningen plugin to pull tests from your README.md into midje."
   :url "https://github.com/boxed/midje-readme"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
watchtower needs to be a proper dependency for (among other things) Travis CI to be able to run this correctly.
